### PR TITLE
Fix HA 2025.6+ compatibility and add custom_components

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,18 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Check push
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: python -m pip install setuptools wheel black pytest
+        run: python -m pip install aiohttp black pytest pytest-asyncio
 
       - run: python3 -m black .
 
-      - name: Install project and test
-        run: |
-            python3 setup.py install
-            python3 setup.py test
+      - name: Install project
+        run: pip install -e .
+
+      - name: Run tests
+        run: python3 -m pytest

--- a/custom_components/carbon_intensity_uk/__init__.py
+++ b/custom_components/carbon_intensity_uk/__init__.py
@@ -1,0 +1,105 @@
+"""
+Custom integration to integrate UK Carbon Intensity API with Home Assistant.
+
+For more details about this integration, please refer to
+https://github.com/jscruz/sensor.carbon_intensity_uk
+"""
+import asyncio
+import logging
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from carbonintensity.client import Client as CarbonIntentisityApi
+
+from .const import (
+    CONF_POSTCODE,
+    DOMAIN,
+    PLATFORMS,
+    STARTUP_MESSAGE,
+)
+
+SCAN_INTERVAL = timedelta(seconds=600)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up this integration using YAML is not supported."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up this integration using UI."""
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+        _LOGGER.info(STARTUP_MESSAGE)
+
+    postcode = entry.data.get(CONF_POSTCODE)
+    _LOGGER.debug("Postcode setup: %s" % postcode)
+
+    coordinator = CarbonIntensityDataUpdateCoordinator(hass, postcode=postcode)
+    _LOGGER.debug("Coordinator refresh triggered")
+    await coordinator.async_refresh()
+    _LOGGER.debug("Coordinator refresh completed")
+
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    platforms = [p for p in PLATFORMS if entry.options.get(p, True)]
+    coordinator.platforms.extend(platforms)
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+    entry.add_update_listener(async_reload_entry)
+    return True
+
+
+class CarbonIntensityDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from the API."""
+
+    def __init__(self, hass, postcode):
+        """Initialize."""
+        self.api = CarbonIntentisityApi(postcode)
+        self.platforms = []
+
+        super().__init__(
+            hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self):
+        """Update data via library."""
+        try:
+            _LOGGER.debug("Coordinator update data async")
+            data = await self.api.async_get_data()
+            _LOGGER.debug("Coordinator update done")
+            return data.get("data", {})
+        except Exception as exception:
+            raise UpdateFailed(exception)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle removal of an entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    unloaded = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+                if platform in coordinator.platforms
+            ]
+        )
+    )
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unloaded
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Reload config entry."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)

--- a/custom_components/carbon_intensity_uk/config_flow.py
+++ b/custom_components/carbon_intensity_uk/config_flow.py
@@ -1,0 +1,106 @@
+"""Adds config flow for Carbon Intensity."""
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+import logging
+_LOGGER = logging.getLogger(__name__)
+
+from carbonintensity.client import Client as CarbonIntentisityApi
+
+from custom_components.carbon_intensity_uk.const import (  # pylint: disable=unused-import
+    CONF_POSTCODE,
+    DOMAIN,
+    PLATFORMS,
+)
+
+
+class CarbonIntensityFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for Carbon Intensity UK."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize."""
+        self._errors = {}
+
+    async def async_step_user(
+        self, user_input=None  # pylint: disable=bad-continuation
+    ):
+        """Handle a flow initialized by the user."""
+        self._errors = {}
+
+        if user_input is not None:
+            valid = await self._test_credentials(user_input[CONF_POSTCODE])
+            if valid:
+                _LOGGER.debug("Input is valid")
+                return self.async_create_entry(
+                    title=user_input[CONF_POSTCODE], data=user_input
+                )
+            else:
+                _LOGGER.debug("Input not valid")
+                self._errors["base"] = "auth"
+
+            return await self._show_config_form(user_input)
+
+        return await self._show_config_form(user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return CarbonIntensityOptionsFlowHandler(config_entry)
+
+    async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
+        """Show the configuration form to edit location data."""
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_POSTCODE): str,}),
+            errors=self._errors,
+        )
+
+    async def _test_credentials(self, postcode):
+        """Return true if credentials is valid."""
+        try:
+            client = CarbonIntentisityApi(postcode)
+            await client.async_get_data()
+            _LOGGER.debug("Input successfully")
+            return True
+        except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.debug(exception)
+        _LOGGER.debug("Oops! Input failed!")
+        return False
+
+
+class CarbonIntensityOptionsFlowHandler(config_entries.OptionsFlow):
+    """Carbon Intensity UK config flow options handler."""
+
+    def __init__(self, config_entry):
+        """Initialize HACS options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
+        """Manage the options."""
+        return await self.async_step_user()
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            self.options.update(user_input)
+            return await self._update_options()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(x, default=self.options.get(x, True)): bool
+                    for x in sorted(PLATFORMS)
+                }
+            ),
+        )
+
+    async def _update_options(self):
+        """Update config entry options."""
+        return self.async_create_entry(
+            title=self.config_entry.data.get(CONF_POSTCODE), data=self.options
+        )

--- a/custom_components/carbon_intensity_uk/const.py
+++ b/custom_components/carbon_intensity_uk/const.py
@@ -1,0 +1,42 @@
+"""Constants for carbon intensity."""
+# Base component constants
+NAME = "Carbon Intensity UK"
+DOMAIN = "carbon_intensity_uk"
+DOMAIN_DATA = f"{DOMAIN}_data"
+VERSION = "0.1.0"
+
+ISSUE_URL = "https://github.com/jscruz/sensor.carbon_intensity_uk/issues"
+
+# Icons
+ICON = "mdi:leaf"
+VERY_LOW_ICON = "mdi:leaf"
+LOW_ICON = "mdi:leaf"
+MODERATE_ICON = "mdi:factory"
+HIGH_ICON = "mdi:smog"
+VERY_HIGH_ICON = "mdi:smog"
+
+# Device classes
+BINARY_SENSOR_DEVICE_CLASS = "connectivity"
+
+# Platforms
+SENSOR = "sensor"
+PLATFORMS = [SENSOR]
+
+
+# Configuration and options
+CONF_ENABLED = "enabled"
+CONF_POSTCODE = "postcode"
+
+# Defaults
+DEFAULT_NAME = DOMAIN
+
+
+STARTUP_MESSAGE = f"""
+-------------------------------------------------------------------
+{NAME}
+Version: {VERSION}
+This is a custom integration!
+If you have any issues with this you need to open an issue here:
+{ISSUE_URL}
+-------------------------------------------------------------------
+"""

--- a/custom_components/carbon_intensity_uk/entity.py
+++ b/custom_components/carbon_intensity_uk/entity.py
@@ -1,0 +1,49 @@
+"""CarbonIntensityEntity class"""
+from homeassistant.helpers import entity
+
+from custom_components.carbon_intensity_uk.const import DOMAIN, VERSION, NAME
+
+
+class CarbonIntensityEntity(entity.Entity):
+    def __init__(self, coordinator, config_entry):
+        self.coordinator = coordinator
+        self.config_entry = config_entry
+
+    @property
+    def should_poll(self):
+        """No need to poll. Coordinator notifies entity of updates."""
+        return False
+
+    @property
+    def available(self):
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for this entity."""
+        return self.config_entry.entry_id
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": NAME,
+            "model": VERSION,
+            "manufacturer": NAME,
+        }
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return self.coordinator.data
+
+    async def async_added_to_hass(self):
+        """Connect to dispatcher listening for entity data notifications."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+    async def async_update(self):
+        """Update Carbon Intensity UK entity."""
+        await self.coordinator.async_request_refresh()

--- a/custom_components/carbon_intensity_uk/manifest.json
+++ b/custom_components/carbon_intensity_uk/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "carbon_intensity_uk",
+  "name": "Carbon Intensity UK",
+  "version": "0.1.0",
+  "config_flow": true,
+  "documentation": "https://github.com/jscruz/sensor.carbon_intensity_uk",
+  "issue_tracker": "https://github.com/jscruz/sensor.carbon_intensity_uk/issues",
+  "requirements": ["aiohttp", "carbonintensity"],
+  "codeowners": ["@jscruz"]
+}

--- a/custom_components/carbon_intensity_uk/sensor.py
+++ b/custom_components/carbon_intensity_uk/sensor.py
@@ -1,0 +1,50 @@
+"""Sensor platform for carbon intensity UK."""
+from custom_components.carbon_intensity_uk.const import (
+    DEFAULT_NAME,
+    DOMAIN,
+    ICON,
+    HIGH_ICON,
+    LOW_ICON,
+    MODERATE_ICON,
+    VERY_HIGH_ICON,
+    VERY_LOW_ICON,
+    SENSOR,
+)
+from custom_components.carbon_intensity_uk.entity import CarbonIntensityEntity
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Setup sensor platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_devices([CarbonIntensitySensor(coordinator, entry)])
+
+
+class CarbonIntensitySensor(CarbonIntensityEntity):
+    """Carbon Intensity Sensor class."""
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{DEFAULT_NAME}"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data.get("current_period_index")
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        index = self.coordinator.data.get("current_period_index")
+        if index == "very high":
+            return VERY_HIGH_ICON
+        elif index == "high":
+            return HIGH_ICON
+        elif index == "moderate":
+            return MODERATE_ICON
+        elif index == "low":
+            return LOW_ICON
+        elif index == "very low":
+            return VERY_LOW_ICON
+        else:
+            return ICON

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
-[aliases]
-test=pytest
-
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [tool:pytest]
 addopts = --verbose

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,8 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/jscruz/carbonintensity",
-    packages=find_packages(),
+    packages=find_packages(exclude=["custom_components*", "tests*"]),
     install_requires=dependencies,
-    setup_requires=["pytest-runner"],
-    tests_require=test_dependencies,
     extras_require={"test": test_dependencies},
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary

Adds the Home Assistant custom component to this repo and applies all pending bug fixes from open issues.

### Changes

- **Fix #14 / #13**: Remove `Config` from `homeassistant.core` import — this class was removed in HA 2026.01. The `async_setup` signature now uses `dict` instead.
- **Fix #12 / #11**: Replace the deprecated (removed in HA 2025.6) `async_forward_entry_setup` (singular) + `async_add_job` pattern with the modern `await hass.config_entries.async_forward_entry_setups(entry, platforms)` (plural, awaited directly).
- **Fix #9**: Rename `device_state_attributes` → `extra_state_attributes` in `entity.py` to match the current HA API.
- **Fix #7**: Extend the `icon` property in `sensor.py` to handle `"very high"` and `"very low"` intensity levels explicitly, preventing a `KeyError` / silent fallback when the grid reaches extreme values. Added corresponding `VERY_HIGH_ICON` / `VERY_LOW_ICON` constants to `const.py`.

## Test plan

- [ ] Load integration in HA 2025.6+ and confirm it sets up without `AttributeError` on `async_forward_entry_setup`
- [ ] Load in HA 2026.1+ and confirm no `ImportError` on `Config`
- [ ] Verify sensor state attributes are exposed (check developer tools → states)
- [ ] Simulate or wait for a "very high" grid intensity period and confirm no icon error in logs