### PR TITLE
Fix "auth" error when adding a postcode in Home Assistant

### DIFF
--- a/carbonintensity/client.py
+++ b/carbonintensity/client.py
@@ -1,6 +1,7 @@
 """Client."""
 from datetime import datetime, timezone
 import logging
+import re
 import aiohttp
 import numpy as np
 
@@ -35,6 +36,29 @@ FOSSIL_FUEL_SOURCES = ["gas", "coal", "oil"]
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
+class CarbonIntensityApiError(Exception):
+    """Raised when the Carbon Intensity API returns an unusable response."""
+
+
+class InvalidPostcodeError(CarbonIntensityApiError):
+    """Raised when the API cannot match the supplied postcode to a region."""
+
+# Full UK postcode without spaces: outward code (e.g. SW1A) + inward code (1AA).
+_FULL_POSTCODE = re.compile(r"([A-Z]{1,2}\d[A-Z\d]?)\d[A-Z]{2}")
+
+
+def normalize_postcode(postcode):
+    """Reduce user postcode input to the outward code the API expects.
+
+    The regional API only matches outward codes (e.g. "SW1A", "RG41");
+    full postcodes, lowercase input, or stray whitespace make it return
+    an empty (null) response.
+    """
+    compact = postcode.strip().upper().replace(" ", "")
+    match = _FULL_POSTCODE.fullmatch(compact)
+    return match.group(1) if match else compact
+
+
 def _get_index(intensity, thresholds):
     """Return the intensity category string for a given gCO2/kWh value."""
     if intensity < thresholds[0]:
@@ -52,7 +76,7 @@ class Client:
     """Carbon Intensity API Client."""
 
     def __init__(self, postcode):
-        self.postcode = postcode
+        self.postcode = normalize_postcode(postcode)
         self.headers = {"Accept": "application/json"}
         _LOGGER.debug(str(self))
 
@@ -77,6 +101,11 @@ class Client:
             async with session.get(request_url, headers=self.headers) as resp:
                 resp.raise_for_status()
                 json_response = await resp.json()
+            # The API answers 200 with a body of "null" for unmatched postcodes.
+            if not json_response or "data" not in json_response:
+                raise InvalidPostcodeError(
+                    "No region found for postcode %s" % self.postcode
+                )
             async with session.get(request_url_national, headers=self.headers) as resp:
                 resp.raise_for_status()
                 json_response_national = await resp.json()
@@ -96,7 +125,10 @@ def generate_response(json_response, json_response_national):
     if len(data) > 96:
         data = data[:96]
     if len(data) < 48:
-        return {"error": "malformed data"}
+        raise CarbonIntensityApiError(
+            "Malformed response: expected at least 48 half-hour periods, got %d"
+            % len(data)
+        )
     # Keep even number of half-hour slots for clean hourly pairing.
     if len(data) % 2 == 1:
         data = data[:-1]

--- a/custom_components/carbon_intensity_uk/config_flow.py
+++ b/custom_components/carbon_intensity_uk/config_flow.py
@@ -1,11 +1,19 @@
 """Adds config flow for Carbon Intensity."""
+import asyncio
+import logging
+
+import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
-import logging
+
 _LOGGER = logging.getLogger(__name__)
 
-from carbonintensity.client import Client as CarbonIntentisityApi
+from carbonintensity.client import (
+    CarbonIntensityApiError,
+    Client as CarbonIntentisityApi,
+    InvalidPostcodeError,
+)
 
 from custom_components.carbon_intensity_uk.const import (  # pylint: disable=unused-import
     CONF_POSTCODE,
@@ -31,15 +39,16 @@ class CarbonIntensityFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
 
         if user_input is not None:
-            valid = await self._test_credentials(user_input[CONF_POSTCODE])
-            if valid:
+            client = CarbonIntentisityApi(user_input[CONF_POSTCODE])
+            error = await self._async_validate_postcode(client)
+            if error is None:
                 _LOGGER.debug("Input is valid")
+                # Store the normalized outward code, not the raw input.
                 return self.async_create_entry(
-                    title=user_input[CONF_POSTCODE], data=user_input
+                    title=client.postcode, data={CONF_POSTCODE: client.postcode}
                 )
-            else:
-                _LOGGER.debug("Input not valid")
-                self._errors["base"] = "auth"
+            _LOGGER.debug("Input not valid: %s", error)
+            self._errors["base"] = error
 
             return await self._show_config_form(user_input)
 
@@ -58,17 +67,23 @@ class CarbonIntensityFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def _test_credentials(self, postcode):
-        """Return true if credentials is valid."""
+    async def _async_validate_postcode(self, client):
+        """Return an error key if the postcode cannot be used, else None."""
         try:
-            client = CarbonIntentisityApi(postcode)
             await client.async_get_data()
-            _LOGGER.debug("Input successfully")
-            return True
-        except Exception as exception:  # pylint: disable=broad-except
+            return None
+        except InvalidPostcodeError as exception:
             _LOGGER.debug(exception)
-        _LOGGER.debug("Oops! Input failed!")
-        return False
+            return "invalid_postcode"
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exception:
+            _LOGGER.debug(exception)
+            return "cannot_connect"
+        except CarbonIntensityApiError as exception:
+            _LOGGER.debug(exception)
+            return "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected error validating postcode")
+            return "unknown"
 
 
 class CarbonIntensityOptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/carbon_intensity_uk/strings.json
+++ b/custom_components/carbon_intensity_uk/strings.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Carbon Intensity UK",
+        "description": "Enter a UK postcode. Only the first part is needed (for example SW1A or RG41), but a full postcode such as SW1A 1AA also works.",
+        "data": {
+          "postcode": "UK postcode"
+        }
+      }
+    },
+    "error": {
+      "invalid_postcode": "Postcode not recognised. Use a UK postcode such as SW1A, RG41 or SW1A 1AA.",
+      "cannot_connect": "Could not retrieve data from the Carbon Intensity API. Check your connection and try again.",
+      "unknown": "Unexpected error. Check the Home Assistant logs for details."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Carbon Intensity UK options",
+        "data": {
+          "sensor": "Enable sensor platform"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/carbon_intensity_uk/translations/en.json
+++ b/custom_components/carbon_intensity_uk/translations/en.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Carbon Intensity UK",
+        "description": "Enter a UK postcode. Only the first part is needed (for example SW1A or RG41), but a full postcode such as SW1A 1AA also works.",
+        "data": {
+          "postcode": "UK postcode"
+        }
+      }
+    },
+    "error": {
+      "invalid_postcode": "Postcode not recognised. Use a UK postcode such as SW1A, RG41 or SW1A 1AA.",
+      "cannot_connect": "Could not retrieve data from the Carbon Intensity API. Check your connection and try again.",
+      "unknown": "Unexpected error. Check the Home Assistant logs for details."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Carbon Intensity UK options",
+        "data": {
+          "sensor": "Enable sensor platform"
+        }
+      }
+    }
+  }
+}

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,4 +1,10 @@
-from carbonintensity.client import Client, generate_response
+from carbonintensity.client import (
+    CarbonIntensityApiError,
+    Client,
+    InvalidPostcodeError,
+    generate_response,
+    normalize_postcode,
+)
 import pytest
 from datetime import datetime, timezone, date
 import os
@@ -16,6 +22,25 @@ def test_string_format():
     client = Client("BH1")
     assert client.postcode == "BH1"
     assert client.headers == {"Accept": "application/json"}
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("BH1", "BH1"),  # outward code passes through
+        ("bh1", "BH1"),  # lowercase
+        (" BH1 ", "BH1"),  # surrounding whitespace
+        ("BH1 1AA", "BH1"),  # full postcode with space
+        ("BH11AA", "BH1"),  # full postcode without space
+        ("SW1A 1AA", "SW1A"),  # A9A-style outward code
+        ("EC1A 1BB", "EC1A"),  # AA9A-style outward code
+        ("M1 1AE", "M1"),  # single-letter area
+        ("CR2 6XH", "CR2"),
+    ],
+)
+def test_normalize_postcode(raw, expected):
+    assert normalize_postcode(raw) == expected
+    assert Client(raw).postcode == expected
 
 
 def test_generate_response():
@@ -68,6 +93,30 @@ def test_generate_response():
     assert isinstance(first["intensity"], float)
     assert first["index"] in VALID_INDEXES
     assert isinstance(first["optimal"], bool)
+
+
+def test_generate_response_raises_on_short_data():
+    with open(TESTRESPONSE_FILENAME) as json_file, open(
+        TESTRESPONSENATIONAL_FILENAME
+    ) as json_national_file:
+        json_response = json.load(json_file)
+        json_national_response = json.load(json_national_file)
+
+    json_response["data"]["data"] = json_response["data"]["data"][:10]
+    with pytest.raises(CarbonIntensityApiError):
+        generate_response(json_response, json_national_response)
+
+
+def test_invalid_postcode_error_is_api_error():
+    # Config flow relies on this hierarchy to map errors to UI messages.
+    assert issubclass(InvalidPostcodeError, CarbonIntensityApiError)
+
+
+@pytest.mark.asyncio
+async def test_request_data_invalid_postcode():
+    # The API returns 200 with a "null" body for unmatched outward codes.
+    with pytest.raises(InvalidPostcodeError):
+        await Client("ZZ99").async_get_data()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The config flow failed for almost any natural postcode input and showed the raw error key "auth". Root cause chain: the regional API only matches outward codes (e.g. SW1A) and answers HTTP 200 with a body of "null" for anything else, the client then crashed with an opaque TypeError, and the config flow swallowed every exception as "auth" — a key with no translation file, so users saw the literal word "auth".