### PR TITLE
Fix automated bump of pypi version based on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ jobs:
     name: Deploy to PyPi
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm needs full history and tags to derive the version
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,6 +9,9 @@ jobs:
     name: Check push
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm needs full history and tags to derive the version
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges start -->
 
-[![Maintained][Maintained]](#)
+[![PyPi version](https://badgen.net/pypi/v/carbon_intensity_uk/)](https://pypi.org/project/carbon_intensity_uk)
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffeelink]
 
 <!-- badges end -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=75.3"]
+requires = ["setuptools>=75.3", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "carbon_intensity_uk"
-version = "1.0.0"
+dynamic = ["version"]
 description = "Home Assistant Client library for Carbon Intensity API"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -28,6 +28,11 @@ Issues = "https://github.com/jscruz/carbonintensity/issues"
 
 [tool.setuptools.packages.find]
 exclude = ["custom_components*", "tests*"]
+
+[tool.setuptools_scm]
+# Version comes from the latest git tag (e.g. tag 1.0.1 -> version 1.0.1).
+# Used when building from a checkout without git metadata or tags:
+fallback_version = "0.0.0"
 
 [tool.pytest.ini_options]
 addopts = "--verbose"


### PR DESCRIPTION
After pushing changes on code, and bumping the version, the problem is that the version in the toml file stays the same meaning that the step in the Github workflow tries to push to Pypi repository the old version.

Fix automated bump of pypi version based on tag